### PR TITLE
Console bug: Method popup window is too small for simple APIs

### DIFF
--- a/dist/assets/console/styles/app.css
+++ b/dist/assets/console/styles/app.css
@@ -1,3 +1,8 @@
+html,body {
+  height: 100%; 
+  margin: 0;  
+  padding: 0;
+}
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;


### PR DESCRIPTION
For simple APIs with one or two calls the method popup of the console is so small it is unusable.  To fix change the height to 100% for the html and body tag.

To verify create an Osprey project from a simple RAML file with two API calls.  Then try clicking the "Try It" button from http://hostname:3000/api/console