### PR TITLE
Fixed a bug in URI template match with URI parameter

### DIFF
--- a/src/uri-template-reader.coffee
+++ b/src/uri-template-reader.coffee
@@ -17,6 +17,7 @@ class UriTemplateReader
     if template? and template.length then template[0] else null
 
   getUriParametersFor: (uri) ->
+    uri = uri.replace(/\?.*$/,'')
     template = @getTemplateFor uri
     return null unless template?
     matches = uri.match template.regexp

--- a/test/spec/uri-template-reader.coffee
+++ b/test/spec/uri-template-reader.coffee
@@ -62,6 +62,17 @@ describe 'URI TEMPLATE READER', ->
     result.should.not.eql null
     result.should.have.property 'resourceId', '1'
 
+  it 'Should correctly read uri parameters for a given uri if it has query parameters', () ->
+    # Arrange
+    uriTemplateReader = new UriTemplateReader @uriTemplates
+
+    # Act
+    result = uriTemplateReader.getUriParametersFor '/resource/1?someParam=somevalue'
+
+    # Assert
+    result.should.not.eql null
+    result.should.have.property 'resourceId', '1'
+
   it 'Should read a null value if uri does not have parameters', () ->
     # Arrange
     uriTemplateReader = new UriTemplateReader @uriTemplates


### PR DESCRIPTION
If the requests has query parameters, the URI template matcher failed
