### PR TITLE
Fix path to RAML in console

### DIFF
--- a/dist/osprey.js
+++ b/dist/osprey.js
@@ -46,10 +46,12 @@
     };
 
     Osprey.prototype.registerConsole = function() {
+      var pathToRaml;
       if (this.settings.enableConsole) {
         this.settings.consolePath = this.apiPath + this.settings.consolePath;
-        this.context.get(this.settings.consolePath, this.consoleHandler(this.apiPath, this.settings.consolePath));
-        this.context.get(url.resolve(this.settings.consolePath + '/', 'index.html'), this.consoleHandler(this.apiPath, this.settings.consolePath));
+        pathToRaml = "" + this.apiPath + "/" + (path.basename(this.settings.ramlFile));
+        this.context.get(this.settings.consolePath, this.consoleHandler(pathToRaml, this.settings.consolePath));
+        this.context.get(url.resolve(this.settings.consolePath + '/', 'index.html'), this.consoleHandler(pathToRaml, this.settings.consolePath));
         this.context.use(this.settings.consolePath, express["static"](path.join(__dirname, 'assets/console')));
         this.context.get(this.apiPath, this.ramlHandler(this.apiPath, this.settings.ramlFile));
         this.context.use(this.apiPath, express["static"](path.dirname(this.settings.ramlFile)));

--- a/src/osprey.coffee
+++ b/src/osprey.coffee
@@ -26,9 +26,10 @@ class Osprey extends OspreyBase
   registerConsole: () =>
     if @settings.enableConsole
       @settings.consolePath = @apiPath + @settings.consolePath
+      pathToRaml = "#{@apiPath}/#{path.basename @settings.ramlFile}"
 
-      @context.get @settings.consolePath, @consoleHandler(@apiPath, @settings.consolePath)
-      @context.get url.resolve(@settings.consolePath + '/', 'index.html'), @consoleHandler(@apiPath, @settings.consolePath)
+      @context.get @settings.consolePath, @consoleHandler(pathToRaml, @settings.consolePath)
+      @context.get url.resolve(@settings.consolePath + '/', 'index.html'), @consoleHandler(pathToRaml, @settings.consolePath)
       @context.use @settings.consolePath, express.static(path.join(__dirname, 'assets/console'))
 
       @context.get @apiPath, @ramlHandler(@apiPath, @settings.ramlFile)


### PR DESCRIPTION
The RAML file is so far given to the console as the base API path (eg. ```http://localhost/api```), which breaks "!include" directives with  relative paths inside the RAML file. This pull request changes the RAML-Path to the API base path plus the actual filename (eg. ```http://localhost/api/api.raml```), so included dependencies will be found by the console.