### PR TITLE
Passing `next` to custom handlers.

### DIFF
--- a/dist/assets/console/styles/app.css
+++ b/dist/assets/console/styles/app.css
@@ -2641,6 +2641,7 @@ raml-console article#raml-console input[type="password"],
 }
 raml-console article#raml-console .parameter-field-input input[type="text"],
 #raml-console-loader .parameter-field-input input[type="text"] {
+  color: #666666;
   font-size: 12px;
   padding: 1px 3px;
 }

--- a/dist/handlers/delete-handler.js
+++ b/dist/handlers/delete-handler.js
@@ -15,7 +15,7 @@
       return MockDeleteHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockDeleteHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockDeleteHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - DELETE " + req.url);
       this.setDefaultHeaders(res, methodInfo);
       return res.send(this.readStatusCode(methodInfo));

--- a/dist/handlers/get-handler.js
+++ b/dist/handlers/get-handler.js
@@ -15,10 +15,10 @@
       return MockGetHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockGetHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockGetHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - GET " + req.url);
       this.setDefaultHeaders(res, methodInfo);
-      return this.negotiateAcceptType(req, res, methodInfo);
+      return this.negotiateAcceptType(req, res, next, methodInfo);
     };
 
     return MockGetHandler;
@@ -39,10 +39,10 @@
       var template;
       template = "" + this.apiPath + uriTemplate;
       return this.context.get(template, (function(_this) {
-        return function(req, res) {
+        return function(req, res, next) {
           var methodInfo;
           methodInfo = _this.methodLookup(_this.resources, 'get', uriTemplate);
-          return _this.negotiateAcceptType(req, res, methodInfo, handler);
+          return _this.negotiateAcceptType(req, res, next, methodInfo, handler);
         };
       })(this));
     };

--- a/dist/handlers/head-handler.js
+++ b/dist/handlers/head-handler.js
@@ -15,7 +15,7 @@
       return MockHeadHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockHeadHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockHeadHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - HEAD " + req.url);
       this.setDefaultHeaders(res, methodInfo);
       return res.send(this.readStatusCode(methodInfo));

--- a/dist/handlers/patch-handler.js
+++ b/dist/handlers/patch-handler.js
@@ -15,11 +15,11 @@
       return MockPatchHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockPatchHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockPatchHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - PATCH " + req.url);
       this.setDefaultHeaders(res, methodInfo);
       this.negotiateContentType(req, res, methodInfo);
-      return this.negotiateAcceptType(req, res, methodInfo);
+      return this.negotiateAcceptType(req, res, next, methodInfo);
     };
 
     return MockPatchHandler;
@@ -40,11 +40,11 @@
       var template;
       template = "" + this.apiPath + uriTemplate;
       return this.context.patch(template, (function(_this) {
-        return function(req, res) {
+        return function(req, res, next) {
           var methodInfo;
           methodInfo = _this.methodLookup(_this.resources, 'patch', uriTemplate);
           _this.negotiateContentType(req, res, methodInfo);
-          return _this.negotiateAcceptType(req, res, methodInfo, handler);
+          return _this.negotiateAcceptType(req, res, next, methodInfo, handler);
         };
       })(this));
     };

--- a/dist/handlers/post-handler.js
+++ b/dist/handlers/post-handler.js
@@ -15,11 +15,11 @@
       return MockPostHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockPostHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockPostHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - POST " + req.url);
       this.setDefaultHeaders(res, methodInfo);
       this.negotiateContentType(req, res, methodInfo);
-      return this.negotiateAcceptType(req, res, methodInfo);
+      return this.negotiateAcceptType(req, res, next, methodInfo);
     };
 
     return MockPostHandler;
@@ -40,11 +40,11 @@
       var template;
       template = "" + this.apiPath + uriTemplate;
       return this.context.post(template, (function(_this) {
-        return function(req, res) {
+        return function(req, res, next) {
           var methodInfo;
           methodInfo = _this.methodLookup(_this.resources, 'post', uriTemplate);
           _this.negotiateContentType(req, res, methodInfo);
-          return _this.negotiateAcceptType(req, res, methodInfo, handler);
+          return _this.negotiateAcceptType(req, res, next, methodInfo, handler);
         };
       })(this));
     };

--- a/dist/handlers/put-handler.js
+++ b/dist/handlers/put-handler.js
@@ -15,11 +15,11 @@
       return MockPutHandler.__super__.constructor.apply(this, arguments);
     }
 
-    MockPutHandler.prototype.resolve = function(req, res, methodInfo) {
+    MockPutHandler.prototype.resolve = function(req, res, next, methodInfo) {
       logger.debug("Mock resolved - PUT " + req.url);
       this.setDefaultHeaders(res, methodInfo);
       this.negotiateContentType(req, res, methodInfo);
-      return this.negotiateAcceptType(req, res, methodInfo);
+      return this.negotiateAcceptType(req, res, next, methodInfo);
     };
 
     return MockPutHandler;
@@ -40,11 +40,11 @@
       var template;
       template = "" + this.apiPath + uriTemplate;
       return this.context.put(template, (function(_this) {
-        return function(req, res) {
+        return function(req, res, next) {
           var methodInfo;
           methodInfo = _this.methodLookup(_this.resources, 'put', uriTemplate);
           _this.negotiateContentType(req, res, methodInfo);
-          return _this.negotiateAcceptType(req, res, methodInfo, handler);
+          return _this.negotiateAcceptType(req, res, next, methodInfo, handler);
         };
       })(this));
     };

--- a/dist/middlewares/router.js
+++ b/dist/middlewares/router.js
@@ -82,7 +82,7 @@
         if ((template != null) && !this.routerExists(method, reqUrl)) {
           methodInfo = this.methodLookup(this.resources, method, template.uriTemplate);
           if ((methodInfo != null) && enableMocks) {
-            this.mockMethodHandlers[method].resolve(req, res, methodInfo);
+            this.mockMethodHandlers[method].resolve(req, res, next, methodInfo);
             return;
           }
         }

--- a/dist/utils/http-utils.js
+++ b/dist/utils/http-utils.js
@@ -56,7 +56,7 @@
       }
     };
 
-    HttpUtils.prototype.negotiateAcceptType = function(req, res, methodInfo, customHandler) {
+    HttpUtils.prototype.negotiateAcceptType = function(req, res, next, methodInfo, customHandler) {
       var isValid, mimeType, response, statusCode, _ref, _ref1, _ref2, _ref3, _ref4;
       statusCode = this.readStatusCode(methodInfo);
       isValid = false;
@@ -73,7 +73,7 @@
         throw new InvalidAcceptTypeError;
       }
       if (customHandler) {
-        return customHandler(req, res);
+        return customHandler(req, res, next);
       } else {
         return res.status(statusCode).send(response);
       }

--- a/src/handlers/delete-handler.coffee
+++ b/src/handlers/delete-handler.coffee
@@ -2,7 +2,7 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockDeleteHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - DELETE #{req.url}"
     @setDefaultHeaders res, methodInfo
     res.send @readStatusCode(methodInfo)

--- a/src/handlers/get-handler.coffee
+++ b/src/handlers/get-handler.coffee
@@ -2,10 +2,10 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockGetHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - GET #{req.url}"
     @setDefaultHeaders res, methodInfo
-    @negotiateAcceptType req, res, methodInfo
+    @negotiateAcceptType req, res, next, methodInfo
 
 class GetHandler extends HttpUtils
   constructor: (@apiPath, @context, @resources) ->
@@ -13,9 +13,9 @@ class GetHandler extends HttpUtils
   resolve: (uriTemplate, handler) =>
     template = "#{@apiPath}#{uriTemplate}"
 
-    @context.get template, (req, res) =>
+    @context.get template, (req, res, next) =>
       methodInfo = @methodLookup @resources, 'get', uriTemplate
-      @negotiateAcceptType req, res, methodInfo, handler
+      @negotiateAcceptType req, res, next, methodInfo, handler
 
 exports.MockHandler = MockGetHandler
 exports.Handler = GetHandler

--- a/src/handlers/head-handler.coffee
+++ b/src/handlers/head-handler.coffee
@@ -2,7 +2,7 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockHeadHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - HEAD #{req.url}"
 
     @setDefaultHeaders res, methodInfo

--- a/src/handlers/patch-handler.coffee
+++ b/src/handlers/patch-handler.coffee
@@ -2,11 +2,11 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockPatchHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - PATCH #{req.url}"
     @setDefaultHeaders res, methodInfo
     @negotiateContentType req, res, methodInfo
-    @negotiateAcceptType req, res, methodInfo
+    @negotiateAcceptType req, res, next, methodInfo
 
 class PatchHandler extends HttpUtils
   constructor: (@apiPath, @context, @resources) ->
@@ -14,10 +14,10 @@ class PatchHandler extends HttpUtils
   resolve: (uriTemplate, handler) =>
     template = "#{@apiPath}#{uriTemplate}"
 
-    @context.patch template, (req, res) =>
+    @context.patch template, (req, res, next) =>
       methodInfo = @methodLookup @resources, 'patch', uriTemplate
       @negotiateContentType req, res, methodInfo
-      @negotiateAcceptType req, res, methodInfo, handler
+      @negotiateAcceptType req, res, next, methodInfo, handler
 
 exports.MockHandler = MockPatchHandler
 exports.Handler = PatchHandler

--- a/src/handlers/post-handler.coffee
+++ b/src/handlers/post-handler.coffee
@@ -2,11 +2,11 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockPostHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - POST #{req.url}"
     @setDefaultHeaders res, methodInfo
     @negotiateContentType req, res, methodInfo
-    @negotiateAcceptType req, res, methodInfo
+    @negotiateAcceptType req, res, next, methodInfo
 
 class PostHandler extends HttpUtils
   constructor: (@apiPath, @context, @resources) ->
@@ -14,10 +14,10 @@ class PostHandler extends HttpUtils
   resolve: (uriTemplate, handler) =>
     template = "#{@apiPath}#{uriTemplate}"
 
-    @context.post template, (req, res) =>
+    @context.post template, (req, res, next) =>
       methodInfo = @methodLookup @resources, 'post', uriTemplate
       @negotiateContentType req, res, methodInfo
-      @negotiateAcceptType req, res, methodInfo, handler
+      @negotiateAcceptType req, res, next, methodInfo, handler
 
 exports.MockHandler = MockPostHandler
 exports.Handler = PostHandler

--- a/src/handlers/put-handler.coffee
+++ b/src/handlers/put-handler.coffee
@@ -2,11 +2,11 @@ HttpUtils = require '../utils/http-utils'
 logger = require '../utils/logger'
 
 class MockPutHandler extends HttpUtils
-  resolve: (req, res, methodInfo) ->
+  resolve: (req, res, next, methodInfo) ->
     logger.debug "Mock resolved - PUT #{req.url}"
     @setDefaultHeaders res, methodInfo
     @negotiateContentType req, res, methodInfo
-    @negotiateAcceptType req, res, methodInfo
+    @negotiateAcceptType req, res, next, methodInfo
 
 class PutHandler extends HttpUtils
   constructor: (@apiPath, @context, @resources) ->
@@ -14,10 +14,10 @@ class PutHandler extends HttpUtils
   resolve: (uriTemplate, handler) =>
     template = "#{@apiPath}#{uriTemplate}"
 
-    @context.put template, (req, res) =>
+    @context.put template, (req, res, next) =>
       methodInfo = @methodLookup @resources, 'put', uriTemplate
       @negotiateContentType req, res, methodInfo
-      @negotiateAcceptType req, res, methodInfo, handler
+      @negotiateAcceptType req, res, next, methodInfo, handler
 
 exports.MockHandler = MockPutHandler
 exports.Handler = PutHandler

--- a/src/middlewares/router.coffee
+++ b/src/middlewares/router.coffee
@@ -51,7 +51,7 @@ class OspreyRouter extends RamlHelper
         methodInfo = @methodLookup @resources, method, template.uriTemplate
 
         if methodInfo? and enableMocks
-          @mockMethodHandlers[method].resolve req, res, methodInfo
+          @mockMethodHandlers[method].resolve req, res, next, methodInfo
           return
 
     next()

--- a/src/utils/http-utils.coffee
+++ b/src/utils/http-utils.coffee
@@ -29,7 +29,7 @@ class HttpUtils extends RamlHelper
     unless isValid
       throw new InvalidContentTypeError
 
-  negotiateAcceptType: (req, res, methodInfo, customHandler) ->
+  negotiateAcceptType: (req, res, next, methodInfo, customHandler) ->
     statusCode = @readStatusCode(methodInfo)
     isValid = false
     response = {}
@@ -45,7 +45,7 @@ class HttpUtils extends RamlHelper
       throw new InvalidAcceptTypeError
 
     if customHandler
-      customHandler req, res
+      customHandler req, res, next
     else
       res.status(statusCode).send(response)
 


### PR DESCRIPTION
Added `next` to all request handlers and mock request handlers. Also, to `negotiateAcceptType` on httpUtils so it get passed along to the `customHandler`.
