### PR TITLE
Fix oauth scope type

### DIFF
--- a/lib/security/handler.js
+++ b/lib/security/handler.js
@@ -205,7 +205,7 @@ function createOAuth2Handler (scheme, opts, key) {
       attachRedirect,
       server.decision(function (req, done) {
         return done(null, {
-          scope: req.body.scope || []
+          scope: arrify(req.body.scope)
         })
       })
     )


### PR DESCRIPTION
When using code or token exchange she serverAuthorizationPage must emit transactionId and scope,
however if the scope requested has only one element (is a array with only one element), the validation will fail, because in the body parsing the scope will be turned in a string, not a array with one element.

To solve this problem a type verification is made, then the type is converted in the correct form

Signed-off-by: Lucas Fernandes de Oliveira <lfo14@inf.ufpr.br>