### PR TITLE
Don't expand type parameters in resourceTypes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -125,7 +125,7 @@ function expandTypes (raml) {
     var isExpandable = data.type &&
       data.type.length === 1 &&
       NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1 &&
-      !data.type[0].matches(/^<<.*>>$/)
+      (typeof data.type[0] !== 'string' || !data.type[0].matches(/^<<.*>>$/))
 
     if (isExpandable) {
       var expanded = dtexp.expandedForm(data, ctx)

--- a/lib/server.js
+++ b/lib/server.js
@@ -147,14 +147,9 @@ function expandTypes (raml) {
     return ctx
   }
 
-  var result = { }
-  for (var key in raml) {
-    if (key === 'resources') {
-      result[key] = _expand(raml[key], ctx)
-    } else {
-      result[key] = raml[key]
-    }
+  if (raml.resources) {
+    raml.resources = _expand(raml.resources, ctx)
   }
 
-  return result
+  return raml
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,8 +124,7 @@ function expandTypes (raml) {
 
     var isExpandable = data.type &&
       data.type.length === 1 &&
-      NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1 &&
-      !data.type[0].match(/<<.*>>/)
+      NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1
 
     if (isExpandable) {
       var expanded = dtexp.expandedForm(data, ctx)
@@ -148,5 +147,14 @@ function expandTypes (raml) {
     return ctx
   }
 
-  return _expand(raml, ctx)
+  var result = { }
+  for (const key in raml) {
+    if (key === 'resources') {
+      result[key] = _expand(raml[key], ctx)
+    } else {
+      result[key] = raml[key]
+    }
+  }
+
+  return result
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,7 +124,8 @@ function expandTypes (raml) {
 
     var isExpandable = data.type &&
       data.type.length === 1 &&
-      NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1
+      NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1 &&
+      !data.type[0].matches(/^<<.*>>$/)
 
     if (isExpandable) {
       var expanded = dtexp.expandedForm(data, ctx)

--- a/lib/server.js
+++ b/lib/server.js
@@ -125,7 +125,7 @@ function expandTypes (raml) {
     var isExpandable = data.type &&
       data.type.length === 1 &&
       NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1 &&
-      (typeof data.type[0] !== 'string' || !data.type[0].matches(/^<<.*>>$/))
+      !data.type[0].match(/^<<.*>>$/)
 
     if (isExpandable) {
       var expanded = dtexp.expandedForm(data, ctx)

--- a/lib/server.js
+++ b/lib/server.js
@@ -148,7 +148,7 @@ function expandTypes (raml) {
   }
 
   var result = { }
-  for (const key in raml) {
+  for (var key in raml) {
     if (key === 'resources') {
       result[key] = _expand(raml[key], ctx)
     } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -125,7 +125,7 @@ function expandTypes (raml) {
     var isExpandable = data.type &&
       data.type.length === 1 &&
       NON_EXPANDABLE_TYPES.indexOf(data.type[0]) === -1 &&
-      !data.type[0].match(/^<<.*>>$/)
+      !data.type[0].match(/<<.*>>/)
 
     if (isExpandable) {
       var expanded = dtexp.expandedForm(data, ctx)

--- a/test/fixtures/types.raml
+++ b/test/fixtures/types.raml
@@ -8,6 +8,27 @@ types:
   Sort:
     type: string
     enum: [desc, asc]
+  Client:
+    type: object
+    properties:
+      id:   integer
+      name: string
+  Resource:
+    type: object
+    properties:
+      name: string
+
+resourceTypes:
+  collection:
+    post:
+      body:
+        application/json:
+          type: <<resourcePathName | !singularize | !uppercamelcase>>
+  apiResource:
+    post:
+      body:
+        application/json:
+          type: <<resourceType>>
 
 /users:
   post:
@@ -75,3 +96,7 @@ types:
           optionalTastes?:
             type: array
             minItems: 1
+/clients:
+  type: collection
+/resource:
+  type: { apiResource: { resourceType: Resource} }

--- a/test/fixtures/types.raml
+++ b/test/fixtures/types.raml
@@ -67,6 +67,16 @@ resourceTypes:
             items: string
             maxItems: 3
             uniqueItems: true
+/arrayRoot:
+  post:
+    body:
+      application/json:
+        type: string[]
+/stringRoot:
+  post:
+    body:
+      application/json:
+        type: string
 /people:
   post:
     body:

--- a/test/fixtures/types.raml
+++ b/test/fixtures/types.raml
@@ -77,6 +77,11 @@ resourceTypes:
     body:
       application/json:
         type: string
+/objectRoot:
+  post:
+    body:
+      application/json:
+        type: object
 /people:
   post:
     body:

--- a/test/types.js
+++ b/test/types.js
@@ -224,4 +224,65 @@ describe('RAML types', function () {
       })
     })
   })
+
+  describe('resource types', function () {
+    it('should accept valid Client bodies', function () {
+      app.post('/clients', success)
+
+      return popsicle.default({
+        url: proxy.url('/clients'),
+        method: 'post',
+        body: {
+          id: 7,
+          name: 'very important client'
+        }
+      }).then(function (res) {
+        expect(res.body).to.equal('success')
+        expect(res.status).to.equal(200)
+      })
+    })
+
+    it('should reject invalid Client bodies', function () {
+      app.post('/clients', success)
+
+      return popsicle.default({
+        url: proxy.url('/clients'),
+        method: 'post',
+        body: {
+          id: '7'
+        }
+      }).then(function (res) {
+        expect(res.status).to.equal(400)
+      })
+    })
+
+    it('should accept valid Resource bodies', function () {
+      app.post('/resource', success)
+
+      return popsicle.default({
+        url: proxy.url('/resource'),
+        method: 'post',
+        body: {
+          name: 'amazing resource'
+        }
+      }).then(function (res) {
+        expect(res.body).to.equal('success')
+        expect(res.status).to.equal(200)
+      })
+    })
+
+    it('should reject invalid Resource bodies', function () {
+      app.post('/resource', success)
+
+      return popsicle.default({
+        url: proxy.url('/resource'),
+        method: 'post',
+        body: {
+          name: 1234
+        }
+      }).then(function (res) {
+        expect(res.status).to.equal(400)
+      })
+    })
+  })
 })

--- a/test/types.js
+++ b/test/types.js
@@ -176,6 +176,35 @@ describe('RAML types', function () {
         expect(res.status).to.equal(400)
       })
     })
+
+    it('should accept arrays as root element', function () {
+      app.post('/arrayRoot', success)
+
+      return popsicle.default({
+        url: proxy.url('/arrayRoot'),
+        method: 'post',
+        body: [
+          'a', 'b', 'c', 'd'
+        ]
+      }).then(function (res) {
+        expect(res.body).to.equal('success')
+        expect(res.status).to.equal(200)
+      })
+    })
+  })
+
+  it('should reject objects when an array is expected as root element', function () {
+    app.post('/arrayRoot', success)
+
+    return popsicle.default({
+      url: proxy.url('/arrayRoot'),
+      method: 'post',
+      body: {
+        foo: 'bar'
+      }
+    }).then(function (res) {
+      expect(res.status).to.equal(400)
+    })
   })
 
   describe('scalar types', function () {
@@ -219,6 +248,33 @@ describe('RAML types', function () {
           dogOrCat: 'fish',
           optionalTastes: []
         }
+      }).then(function (res) {
+        expect(res.status).to.equal(400)
+      })
+    })
+
+    it('should accept strings as root element', function () {
+      app.post('/stringRoot', success)
+
+      return popsicle.default({
+        url: proxy.url('/stringRoot'),
+        method: 'post',
+        body: '"test"',
+        headers: { 'Content-Type': 'application/json' }
+      }).then(function (res) {
+        expect(res.body).to.equal('success')
+        expect(res.status).to.equal(200)
+      })
+    })
+
+    it('should reject integers when a string is expected as root element', function () {
+      app.post('/stringRoot', success)
+
+      return popsicle.default({
+        url: proxy.url('/stringRoot'),
+        method: 'post',
+        body: 7,
+        headers: { 'Content-Type': 'application/json' }
       }).then(function (res) {
         expect(res.status).to.equal(400)
       })

--- a/test/types.js
+++ b/test/types.js
@@ -281,6 +281,35 @@ describe('RAML types', function () {
     })
   })
 
+  it('should accept objects as root element', function () {
+    app.post('/objectRoot', success)
+
+    return popsicle.default({
+      url: proxy.url('/objectRoot'),
+      method: 'post',
+      body: {
+        foo: 'bar'
+      },
+      headers: { 'Content-Type': 'application/json' }
+    }).then(function (res) {
+      expect(res.body).to.equal('success')
+      expect(res.status).to.equal(200)
+    })
+  })
+
+  it('should reject integers when an object is expected as root element', function () {
+    app.post('/objectRoot', success)
+
+    return popsicle.default({
+      url: proxy.url('/stringRoot'),
+      method: 'post',
+      body: 7,
+      headers: { 'Content-Type': 'application/json' }
+    }).then(function (res) {
+      expect(res.status).to.equal(400)
+    })
+  })
+
   describe('resource types', function () {
     it('should accept valid Client bodies', function () {
       app.post('/clients', success)


### PR DESCRIPTION
Osprey tries to expand Resource Type Parameters, resulting in an error. However, `raml-1-parser` already takes care of replacing Resource Type Parameters with their assigned values, so they shouldn't be of any concern to Osprey. This little change prevents Osprey from trying to perform type-expansion on these parameters.

Fixes #134.