### PR TITLE
Basic HTTP Authentication: add support for passport option "passReqToCallback"

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ securitySchemes:
 osprey.security(raml, {
   basic_auth: {
     realm: 'Users', // Optional.
+    passReqToCallback: false, // Optional. Default value: false. If true "req" is added as the first callback argument. 
     validateUser: function (username, password, done) {
       User.findOne({ username: username }, function (err, user) {
         if (err) { return done(err) }

--- a/lib/security/handler.js
+++ b/lib/security/handler.js
@@ -347,7 +347,7 @@ function createBasicAuthHandler (scheme, options, key) {
   )
 
   passport.use(KEY, new BasicStrategy(
-    { realm: options.realm },
+    { realm: options.realm, passReqToCallback: options.passReqToCallback },
     options.validateUser
   ))
 


### PR DESCRIPTION
Fixes #147 