### PR TITLE
fix(dependencies): bumping version of yargs to deal with nexus vulner…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/generator": {
@@ -19,11 +19,11 @@
       "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.4.4",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -40,9 +40,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -51,7 +51,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -60,7 +60,7 @@
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/highlight": {
@@ -69,9 +69,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -86,9 +86,9 @@
       "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/traverse": {
@@ -97,15 +97,15 @@
       "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.4.4",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "@babel/parser": "7.4.4",
+        "@babel/types": "7.4.4",
+        "debug": "4.1.0",
+        "globals": "11.9.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/types": {
@@ -114,9 +114,9 @@
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@types/concat-stream": {
@@ -125,7 +125,7 @@
       "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.12"
       }
     },
     "@types/debug": {
@@ -139,7 +139,7 @@
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.12"
       }
     },
     "@types/methods": {
@@ -164,7 +164,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.21",
         "negotiator": "0.6.1"
       }
     },
@@ -180,7 +180,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -196,10 +196,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
       "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-keywords": {
@@ -228,7 +228,8 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -248,7 +249,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "2.0.0"
       }
     },
     "archy": {
@@ -263,7 +264,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-flatten": {
@@ -277,8 +278,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0"
       }
     },
     "arrify": {
@@ -303,9 +304,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -320,11 +321,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "js-tokens": {
@@ -339,7 +340,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -367,15 +368,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -391,10 +392,10 @@
           "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         }
       }
@@ -405,7 +406,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -446,10 +447,10 @@
       "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
       "dev": true,
       "requires": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
+        "hasha": "3.0.0",
+        "make-dir": "2.1.0",
+        "package-hash": "3.0.0",
+        "write-file-atomic": "2.4.2"
       }
     },
     "caller-path": {
@@ -458,7 +459,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -472,8 +473,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -487,12 +488,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -501,9 +502,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -512,7 +513,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "has-flag": {
@@ -527,7 +528,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -537,24 +538,24 @@
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
       "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
       "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "constant-case": "2.0.0",
+        "dot-case": "2.1.1",
+        "header-case": "1.0.1",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "no-case": "2.3.2",
+        "param-case": "2.1.1",
+        "pascal-case": "2.0.1",
+        "path-case": "2.1.1",
+        "sentence-case": "2.1.1",
+        "snake-case": "2.1.0",
+        "swap-case": "1.1.2",
+        "title-case": "2.1.1",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
       }
     },
     "chardet": {
@@ -581,7 +582,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -596,8 +597,8 @@
       "integrity": "sha512-wYr6y+7gh+XtpX4wmmWiq+XPWe/worg92evt8+LB3ODUQLaafKrdtRVEdvF/fGQRyCtIlb2/6BS1AzHgyP86Tg==",
       "dev": true,
       "requires": {
-        "popsicle": "^10.0.0",
-        "safe-buffer": "^5.1.1"
+        "popsicle": "10.0.1",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "popsicle": {
@@ -606,14 +607,14 @@
           "integrity": "sha512-IFVBRz+hc05+MiVDH+KH9QoeE6gjFOiIZNxKePIwz+JbH/yP9rLreUT9+GocxRweYBiRh7O9+MfI5X1zKfSH6Q==",
           "dev": true,
           "requires": {
-            "@types/concat-stream": "^1.6.0",
+            "@types/concat-stream": "1.6.0",
             "@types/form-data": "0.0.33",
-            "@types/methods": "^1.1.0",
-            "@types/tough-cookie": "^2.3.0",
-            "concat-stream": "^1.4.7",
-            "form-data": "^2.0.0",
-            "make-error-cause": "^1.2.1",
-            "tough-cookie": "^2.0.0"
+            "@types/methods": "1.1.0",
+            "@types/tough-cookie": "2.3.5",
+            "concat-stream": "1.6.2",
+            "form-data": "2.3.3",
+            "make-error-cause": "1.2.2",
+            "tough-cookie": "2.5.0"
           }
         }
       }
@@ -622,10 +623,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       }
     },
     "co": {
@@ -637,13 +639,13 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -651,15 +653,14 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -680,8 +681,8 @@
       "integrity": "sha512-Rcv19QgPOtYHu8wDJsu4ehSfkqSXjQLwKRXhIy9TFiIijSZz330ORyLCeirb4sPuBBbDNC5lUvQLuM72vWjKSQ==",
       "requires": {
         "@types/debug": "0.0.31",
-        "array-flatten": "^2.1.2",
-        "debug": "^4.1.0"
+        "array-flatten": "2.1.2",
+        "debug": "4.1.0"
       }
     },
     "compressible": {
@@ -689,7 +690,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
       "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
       "requires": {
-        "mime-db": ">= 1.36.0 < 2"
+        "mime-db": "1.37.0"
       }
     },
     "compression": {
@@ -697,13 +698,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "2.0.15",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -728,10 +729,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -746,13 +747,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -761,7 +762,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -771,8 +772,8 @@
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
       }
     },
     "contains-path": {
@@ -798,7 +799,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "cookie": {
@@ -814,7 +815,7 @@
       "requires": {
         "cookies": "0.7.1",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1"
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -838,8 +839,8 @@
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
       "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
       "requires": {
-        "depd": "~1.1.1",
-        "keygrip": "~1.0.2"
+        "depd": "1.1.2",
+        "keygrip": "1.0.3"
       }
     },
     "core-js": {
@@ -858,8 +859,8 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
       }
     },
     "cp-file": {
@@ -868,11 +869,11 @@
       "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
+        "graceful-fs": "4.1.15",
+        "make-dir": "2.1.0",
+        "nested-error-stacks": "2.1.0",
+        "pify": "4.0.1",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "pify": {
@@ -887,12 +888,13 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "datatype-expansion": {
@@ -900,7 +902,7 @@
       "resolved": "https://registry.npmjs.org/datatype-expansion/-/datatype-expansion-0.3.6.tgz",
       "integrity": "sha512-EksLh8DuzllOZ9HJddIh0E0LC1BnLyPQ72bTOWKNSeEdsjSNje6jcIaIKCRjgppqCjIUYdX4pp2/gUocwH3M/g==",
       "requires": {
-        "lodash": "^4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "date-and-time": {
@@ -913,7 +915,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.1"
       },
       "dependencies": {
         "ms": {
@@ -940,7 +942,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-is": {
@@ -955,7 +957,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "3.0.0"
       }
     },
     "define-properties": {
@@ -964,7 +966,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "deglob": {
@@ -973,12 +975,12 @@
       "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
       "dev": true,
       "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
+        "find-root": "1.1.0",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.9",
+        "uniq": "1.0.1"
       },
       "dependencies": {
         "glob": {
@@ -987,12 +989,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1033,7 +1035,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dot": {
@@ -1046,7 +1048,7 @@
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "ee-first": {
@@ -1068,8 +1070,9 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "error-ex": {
@@ -1078,7 +1081,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1087,11 +1090,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1100,9 +1103,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "es6-error": {
@@ -1134,44 +1137,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.2.6",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.3",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.3",
+        "globals": "11.9.0",
+        "ignore": "3.3.10",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.3",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.6.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
         "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -1180,10 +1183,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "cross-spawn": {
@@ -1192,9 +1195,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "debug": {
@@ -1203,7 +1206,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "fast-deep-equal": {
@@ -1218,12 +1221,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "json-schema-traverse": {
@@ -1258,8 +1261,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -1277,7 +1280,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -1288,8 +1291,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1309,8 +1312,8 @@
       "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.3.0",
-        "regexpp": "^2.0.1"
+        "eslint-utils": "1.3.1",
+        "regexpp": "2.0.1"
       },
       "dependencies": {
         "regexpp": {
@@ -1327,16 +1330,16 @@
       "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "dev": true,
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.3",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -1354,8 +1357,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "isarray": {
@@ -1370,7 +1373,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -1381,12 +1384,12 @@
       "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.3.1",
-        "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
+        "eslint-plugin-es": "1.4.0",
+        "eslint-utils": "1.3.1",
+        "ignore": "4.0.6",
+        "minimatch": "3.0.4",
+        "resolve": "1.8.1",
+        "semver": "5.6.0"
       },
       "dependencies": {
         "ignore": {
@@ -1401,7 +1404,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -1418,11 +1421,11 @@
       "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
+        "array-includes": "3.0.3",
+        "doctrine": "2.1.0",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.2"
       }
     },
     "eslint-plugin-standard": {
@@ -1437,8 +1440,8 @@
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1467,8 +1470,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.7.3",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esquery": {
@@ -1477,7 +1480,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1494,7 +1497,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1521,14 +1524,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "express": {
@@ -1537,36 +1541,36 @@
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -1598,9 +1602,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -1625,7 +1629,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1634,8 +1638,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "finalhandler": {
@@ -1644,12 +1648,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1673,9 +1677,9 @@
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "2.1.0",
+        "pkg-dir": "3.0.0"
       },
       "dependencies": {
         "pkg-dir": {
@@ -1684,7 +1688,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         }
       }
@@ -1700,7 +1704,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "flat": {
@@ -1709,7 +1713,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "2.0.3"
       }
     },
     "flat-cache": {
@@ -1718,10 +1722,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.15",
+        "rimraf": "2.6.2",
+        "write": "0.2.1"
       }
     },
     "foreground-child": {
@@ -1730,8 +1734,8 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -1740,8 +1744,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "which": "1.3.1"
           }
         }
       }
@@ -1751,9 +1755,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "forwarded": {
@@ -1773,9 +1777,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.15",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs.realpath": {
@@ -1817,8 +1821,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "globals": {
@@ -1844,7 +1849,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1853,7 +1858,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1876,7 +1881,7 @@
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1"
+        "is-stream": "1.1.0"
       }
     },
     "he": {
@@ -1890,8 +1895,8 @@
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "hosted-git-info": {
@@ -1905,10 +1910,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
       "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "1.5.0",
         "toidentifier": "1.0.0"
       }
     },
@@ -1917,7 +1922,7 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
       "integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
       "requires": {
-        "@types/node": "^9.3.0"
+        "@types/node": "9.6.48"
       },
       "dependencies": {
         "@types/node": {
@@ -1932,7 +1937,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -1953,8 +1958,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1968,20 +1973,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       }
     },
     "invariant": {
@@ -1989,13 +1994,14 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -2021,7 +2027,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -2046,7 +2052,7 @@
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "requires": {
-        "lower-case": "^1.1.0"
+        "lower-case": "1.1.4"
       }
     },
     "is-promise": {
@@ -2061,7 +2067,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-resolvable": {
@@ -2073,7 +2079,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -2081,7 +2088,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-upper-case": {
@@ -2089,13 +2096,14 @@
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "requires": {
-        "upper-case": "^1.1.0"
+        "upper-case": "1.1.3"
       }
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -2109,7 +2117,7 @@
       "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -2118,13 +2126,13 @@
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
+        "@babel/generator": "7.4.4",
+        "@babel/parser": "7.4.4",
+        "@babel/template": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4",
+        "istanbul-lib-coverage": "2.0.5",
+        "semver": "6.0.0"
       },
       "dependencies": {
         "semver": {
@@ -2141,9 +2149,9 @@
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "has-flag": {
@@ -2158,7 +2166,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2169,11 +2177,11 @@
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
+        "debug": "4.1.1",
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "rimraf": "2.6.3",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -2182,7 +2190,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "glob": {
@@ -2191,12 +2199,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "ms": {
@@ -2211,7 +2219,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "source-map": {
@@ -2228,7 +2236,7 @@
       "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "handlebars": "4.1.2"
       },
       "dependencies": {
         "handlebars": {
@@ -2237,10 +2245,10 @@
           "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
           "dev": true,
           "requires": {
-            "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
+            "neo-async": "2.6.0",
+            "optimist": "0.6.1",
+            "source-map": "0.6.1",
+            "uglify-js": "3.4.9"
           }
         },
         "source-map": {
@@ -2262,8 +2270,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       },
       "dependencies": {
         "esprima": {
@@ -2291,7 +2299,7 @@
       "resolved": "https://registry.npmjs.org/json-path/-/json-path-0.1.3.tgz",
       "integrity": "sha1-3OYTV7OygbKKxkfsCnCbxYoVW/g=",
       "requires": {
-        "json-ptr": "~0.1.1"
+        "json-ptr": "0.1.1"
       }
     },
     "json-ptr": {
@@ -2314,7 +2322,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -2333,7 +2341,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.15"
       }
     },
     "jsonify": {
@@ -2347,7 +2355,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "3.0.3"
       }
     },
     "keygrip": {
@@ -2360,15 +2368,16 @@
       "resolved": "https://registry.npmjs.org/know-your-http-well/-/know-your-http-well-0.5.0.tgz",
       "integrity": "sha1-XQOQAxBHmanXf8KZjP1TlnWyVr4=",
       "requires": {
-        "amdefine": "~0.0.4"
+        "amdefine": "0.0.8"
       }
     },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "levn": {
@@ -2377,8 +2386,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -2387,10 +2396,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -2398,8 +2407,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -2429,7 +2438,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "loophole": {
@@ -2442,7 +2451,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "lower-case": {
@@ -2455,7 +2464,7 @@
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "requires": {
-        "lower-case": "^1.1.2"
+        "lower-case": "1.1.4"
       }
     },
     "lowercase-keys": {
@@ -2469,8 +2478,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "lrucache": {
@@ -2484,8 +2493,8 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "pify": "4.0.1",
+        "semver": "5.6.0"
       },
       "dependencies": {
         "pify": {
@@ -2508,15 +2517,16 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "^1.2.0"
+        "make-error": "1.3.5"
       }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "media-typer": {
@@ -2528,16 +2538,18 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "2.1.0",
+        "p-is-promise": "2.1.0"
       },
       "dependencies": {
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
         }
       }
     },
@@ -2553,7 +2565,7 @@
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2585,7 +2597,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "mimic-fn": {
@@ -2600,7 +2612,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2647,13 +2659,19 @@
         "yargs-unparser": "1.5.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "esprima": {
@@ -2668,12 +2686,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -2688,8 +2706,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         },
         "ms": {
@@ -2698,13 +2716,52 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        },
         "supports-color": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "2.0.5",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "2.0.0",
+            "set-blocking": "2.0.0",
+            "string-width": "3.1.0",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "13.0.0"
           }
         },
         "yargs-parser": {
@@ -2713,8 +2770,8 @@
           "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -2756,14 +2813,15 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node-environment-flags": {
@@ -2772,8 +2830,8 @@
       "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
+        "object.getownpropertydescriptors": "2.0.3",
+        "semver": "5.7.0"
       },
       "dependencies": {
         "semver": {
@@ -2790,24 +2848,26 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "14.1.0",
@@ -2815,31 +2875,31 @@
       "integrity": "sha512-iy9fEV8Emevz3z/AanIZsoGa8F4U2p0JKevZ/F0sk+/B2r9E6Qn+EPs0bpxEhnAt6UPlTL8mQZIaSJy8sK0ZFw==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
+        "archy": "1.0.0",
+        "caching-transform": "3.0.2",
+        "convert-source-map": "1.6.0",
+        "cp-file": "6.2.0",
+        "find-cache-dir": "2.1.0",
+        "find-up": "3.0.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.3",
+        "istanbul-lib-coverage": "2.0.5",
+        "istanbul-lib-hook": "2.0.7",
+        "istanbul-lib-instrument": "3.3.0",
+        "istanbul-lib-report": "2.0.8",
+        "istanbul-lib-source-maps": "3.0.6",
+        "istanbul-reports": "2.2.4",
+        "js-yaml": "3.13.1",
+        "make-dir": "2.1.0",
+        "merge-source-map": "1.1.0",
+        "resolve-from": "4.0.0",
+        "rimraf": "2.6.3",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "5.2.3",
+        "uuid": "3.3.2",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.0"
       },
       "dependencies": {
         "esprima": {
@@ -2854,12 +2914,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "js-yaml": {
@@ -2868,8 +2928,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         },
         "resolve-from": {
@@ -2884,7 +2944,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         }
       }
@@ -2894,9 +2954,9 @@
       "resolved": "https://registry.npmjs.org/oauth2orize/-/oauth2orize-1.11.0.tgz",
       "integrity": "sha1-eTzvJR1F696sMq5AqLaBT6qx1IM=",
       "requires": {
-        "debug": "2.x.x",
-        "uid2": "0.0.x",
-        "utils-merge": "1.x.x"
+        "debug": "2.6.9",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -2931,10 +2991,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       }
     },
     "object.getownpropertydescriptors": {
@@ -2943,8 +3003,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0"
       }
     },
     "on-finished": {
@@ -2964,8 +3024,9 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -2974,7 +3035,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -2983,8 +3044,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
@@ -3001,12 +3062,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-homedir": {
@@ -3019,10 +3080,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.3.0"
       }
     },
     "os-shim": {
@@ -3042,24 +3104,24 @@
       "resolved": "https://registry.npmjs.org/osprey-method-handler/-/osprey-method-handler-0.12.3.tgz",
       "integrity": "sha512-6eLqukrc8Ks7XDr8cIlOT+wZi/1f8gNHBPGZPJSBn0tQcho0l0lKcGG8tSUcv/LZ4Upsg9846DnXsOoRZ2MTMg==",
       "requires": {
-        "ajv": "^6.4.0",
-        "body-parser": "^1.15.2",
-        "busboy": "^0.3.1",
-        "compose-middleware": "^5.0.0",
-        "debug": "^4.0.0",
-        "http-errors": "^1.2.8",
-        "is-stream": "^2.0.0",
-        "json-schema-compatibility": "^1.0.1",
-        "lowercase-keys": "^2.0.0",
-        "negotiator": "^0.6.0",
-        "object-values": "^2.0.0",
-        "parseurl": "^1.3.0",
-        "raml-sanitize": "^1.3.4",
-        "raml-validate": "^1.2.3",
-        "standard-headers": "^0.1.0",
-        "stream-equal": "^1.1.1",
-        "type-is": "^1.5.5",
-        "xtend": "^4.0.0"
+        "ajv": "6.6.1",
+        "body-parser": "1.18.3",
+        "busboy": "0.3.1",
+        "compose-middleware": "5.0.1",
+        "debug": "4.1.0",
+        "http-errors": "1.7.1",
+        "is-stream": "2.0.0",
+        "json-schema-compatibility": "1.1.0",
+        "lowercase-keys": "2.0.0",
+        "negotiator": "0.6.1",
+        "object-values": "2.0.0",
+        "parseurl": "1.3.2",
+        "raml-sanitize": "1.3.4",
+        "raml-validate": "1.2.3",
+        "standard-headers": "0.1.1",
+        "stream-equal": "1.1.1",
+        "type-is": "1.6.16",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "is-stream": {
@@ -3074,8 +3136,8 @@
       "resolved": "https://registry.npmjs.org/osprey-resources/-/osprey-resources-0.8.2.tgz",
       "integrity": "sha512-59FDKgKcFadIoyF/koqan/773QoPT4NJzANIu+aZTegzyW2C9toBVvlPvP20F5JAuA3enMfGEOZhZM3ljX9vMg==",
       "requires": {
-        "osprey-router": "^0.6.2",
-        "xtend": "^4.0.1"
+        "osprey-router": "0.6.2",
+        "xtend": "4.0.1"
       }
     },
     "osprey-router": {
@@ -3083,34 +3145,81 @@
       "resolved": "https://registry.npmjs.org/osprey-router/-/osprey-router-0.6.2.tgz",
       "integrity": "sha512-a65yvr6il3hVD0Wus2kuxdUCfVeyxy1WHTtwEjSqUt4XIwR0hyztSacaQu/09qXOvbTMwc4k89IEJPeTCqq+pw==",
       "requires": {
-        "array-flatten": "^2.0.0",
-        "methods": "^1.1.1",
-        "raml-path-match": "^2.2.2",
+        "array-flatten": "2.1.2",
+        "methods": "1.1.2",
+        "raml-path-match": "2.2.2",
         "router": "github:blakeembrey/router#5eb68560e91b302251ff17a70cd1b6af1fc36d30",
-        "xtend": "^4.0.1"
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "router": {
+          "version": "github:blakeembrey/router#5eb68560e91b302251ff17a70cd1b6af1fc36d30",
+          "requires": {
+            "array-flatten": "2.0.0",
+            "debug": "3.2.6",
+            "methods": "1.1.2",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "setprototypeof": "1.0.0",
+            "utils-merge": "1.0.0"
+          },
+          "dependencies": {
+            "array-flatten": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.0.0.tgz",
+              "integrity": "sha1-JN2Ys4uRlLWbIIe6QMIThNa4qNw="
+            }
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.0.tgz",
+          "integrity": "sha1-1fr8oB4RdNAHm9G/iB8JyKM5eUw="
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        }
       }
     },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.2.0"
       }
     },
     "p-locate": {
@@ -3118,7 +3227,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.2.0"
       }
     },
     "p-try": {
@@ -3132,10 +3241,10 @@
       "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
+        "graceful-fs": "4.1.15",
+        "hasha": "3.0.0",
+        "lodash.flattendeep": "4.4.0",
+        "release-zalgo": "1.0.0"
       }
     },
     "param-case": {
@@ -3143,7 +3252,7 @@
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-json": {
@@ -3152,7 +3261,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parseurl": {
@@ -3165,8 +3274,8 @@
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "upper-case-first": "1.1.2"
       }
     },
     "passport": {
@@ -3174,7 +3283,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
       "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
       "requires": {
-        "passport-strategy": "1.x.x",
+        "passport-strategy": "1.0.0",
         "pause": "0.0.1"
       }
     },
@@ -3183,7 +3292,7 @@
       "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
       "integrity": "sha1-juU9Q4C+nGDfIVGSUCmCb3cRVgM=",
       "requires": {
-        "passport-strategy": "1.x.x"
+        "passport-strategy": "1.0.0"
       }
     },
     "passport-http-bearer": {
@@ -3191,7 +3300,7 @@
       "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
       "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
       "requires": {
-        "passport-strategy": "1.x.x"
+        "passport-strategy": "1.0.0"
       }
     },
     "passport-oauth2-client-password": {
@@ -3199,7 +3308,7 @@
       "resolved": "https://registry.npmjs.org/passport-oauth2-client-password/-/passport-oauth2-client-password-0.1.2.tgz",
       "integrity": "sha1-TzeLZ4uS0W270jOmxwZSAJPlYbo=",
       "requires": {
-        "passport-strategy": "1.x.x"
+        "passport-strategy": "1.0.0"
       }
     },
     "passport-strategy": {
@@ -3212,7 +3321,7 @@
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "path-exists": {
@@ -3235,7 +3344,8 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -3254,7 +3364,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pathval": {
@@ -3286,7 +3396,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-conf": {
@@ -3295,8 +3405,8 @@
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "2.1.0",
+        "load-json-file": "4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3305,7 +3415,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -3314,10 +3424,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.15",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -3326,8 +3436,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -3336,7 +3446,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -3345,7 +3455,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -3360,8 +3470,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "pify": {
@@ -3378,9 +3488,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
       }
     },
     "pkg-dir": {
@@ -3389,7 +3499,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       },
       "dependencies": {
         "find-up": {
@@ -3398,8 +3508,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -3408,7 +3518,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -3424,14 +3534,14 @@
       "integrity": "sha512-IFVBRz+hc05+MiVDH+KH9QoeE6gjFOiIZNxKePIwz+JbH/yP9rLreUT9+GocxRweYBiRh7O9+MfI5X1zKfSH6Q==",
       "dev": true,
       "requires": {
-        "@types/concat-stream": "^1.6.0",
+        "@types/concat-stream": "1.6.0",
         "@types/form-data": "0.0.33",
-        "@types/methods": "^1.1.0",
-        "@types/tough-cookie": "^2.3.0",
-        "concat-stream": "^1.4.7",
-        "form-data": "^2.0.0",
-        "make-error-cause": "^1.2.1",
-        "tough-cookie": "^2.0.0"
+        "@types/methods": "1.1.0",
+        "@types/tough-cookie": "2.3.5",
+        "concat-stream": "1.6.2",
+        "form-data": "2.3.3",
+        "make-error-cause": "1.2.2",
+        "tough-cookie": "2.5.0"
       }
     },
     "popsicle-basic-auth": {
@@ -3446,8 +3556,8 @@
       "integrity": "sha1-unwnOzITZ6QNKGPtshCMNQJ1/pg=",
       "dev": true,
       "requires": {
-        "promise-finally": "^2.1.0",
-        "server-address": "^1.0.0"
+        "promise-finally": "2.2.1",
+        "server-address": "1.0.4"
       },
       "dependencies": {
         "server-address": {
@@ -3456,7 +3566,7 @@
           "integrity": "sha1-BI0NURMqKV4IpKJhN/fRoeavIOg=",
           "dev": true,
           "requires": {
-            "server-destroy": "^1.0.0"
+            "server-destroy": "1.0.1"
           }
         }
       }
@@ -3467,9 +3577,9 @@
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3478,9 +3588,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "shebang-command": "1.2.0",
+            "which": "1.2.14"
           }
         },
         "which": {
@@ -3489,7 +3599,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -3518,7 +3628,7 @@
       "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.3.0"
+        "any-promise": "1.3.0"
       }
     },
     "promise-polyfill": {
@@ -3532,8 +3642,8 @@
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "proxy-addr": {
@@ -3542,7 +3652,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -3562,9 +3672,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -3604,7 +3715,7 @@
         "raml-definition-system": "0.0.87",
         "ts-model": "0.0.18",
         "underscore": "1.9.1",
-        "urlsafe-base64": "^1.0.0",
+        "urlsafe-base64": "1.0.0",
         "xhr2": "0.1.4",
         "xmldom": "0.1.27",
         "xmlhttprequest": "1.8.0",
@@ -3622,11 +3733,11 @@
           "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.0.1.tgz",
           "integrity": "sha512-eYi6JZ3iq01zIpDLXbz9oQrstXVQ6dtR0u6nXGsCG+dDDtcDi7p2r2zCrih5n6brb35b+ad7H/mSimV8KckxCQ==",
           "requires": {
-            "commander": "^2.7.1",
-            "core-js": "^2.5.7",
-            "lodash.get": "^4.4.2",
-            "lodash.isequal": "^4.5.0",
-            "validator": "^10.11.0"
+            "commander": "2.20.0",
+            "core-js": "2.6.5",
+            "lodash.get": "4.4.2",
+            "lodash.isequal": "4.5.0",
+            "validator": "10.11.0"
           }
         }
       }
@@ -3686,9 +3797,9 @@
       "resolved": "https://registry.npmjs.org/raml-path-match/-/raml-path-match-2.2.2.tgz",
       "integrity": "sha512-1SYmFXB/21FNFHl/UUdmpUhO74afIhWlLxvAP0vC3OAOZaD4b8ewai1oky90UBytMs3OhMxFmPSyVpHv4Yqy+Q==",
       "requires": {
-        "raml-sanitize": "^1.3.4",
-        "raml-validate": "^1.2.3",
-        "xtend": "^4.0.1"
+        "raml-sanitize": "1.3.4",
+        "raml-validate": "1.2.3",
+        "xtend": "4.0.1"
       }
     },
     "raml-sanitize": {
@@ -3719,7 +3830,7 @@
       "resolved": "https://registry.npmjs.org/raml-validate/-/raml-validate-1.2.3.tgz",
       "integrity": "sha512-L9mCI8WJAGSZm/k/BmD5qLpGm1X8oM09XVwrORbzKhYvjqg0aHuMXa78zFyJf82S0JlUcqeZdNmGcI2WgC+Crg==",
       "requires": {
-        "raml-typesystem": "^0.0.91"
+        "raml-typesystem": "0.0.91"
       }
     },
     "raml-xml-validation": {
@@ -3753,10 +3864,10 @@
           "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         }
       }
@@ -3767,9 +3878,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -3778,8 +3889,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3788,7 +3899,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -3797,8 +3908,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -3807,7 +3918,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -3816,7 +3927,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -3839,7 +3950,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "^4.0.1"
+        "es6-error": "4.1.1"
       }
     },
     "request-error-handler": {
@@ -3847,12 +3958,12 @@
       "resolved": "https://registry.npmjs.org/request-error-handler/-/request-error-handler-1.1.1.tgz",
       "integrity": "sha512-X2UoBKID5bgITHIMPEtLLUTiOa1h8K8zATKKxdvAs+Dlnl84oLW9QFFodRlTyBnBRt+5WnL8O39/wT8XK3g6Fw==",
       "requires": {
-        "debug": "^4.0.0",
-        "dot": "^1.0.3",
-        "escape-html": "^1.0.2",
-        "invariant": "^2.1.0",
-        "negotiator": "^0.6.1",
-        "xtend": "^4.0.0"
+        "debug": "4.1.0",
+        "dot": "1.1.2",
+        "escape-html": "1.0.3",
+        "invariant": "2.2.4",
+        "negotiator": "0.6.1",
+        "xtend": "4.0.1"
       }
     },
     "require-directory": {
@@ -3871,8 +3982,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve-from": {
@@ -3887,8 +3998,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "rewire": {
@@ -3897,7 +4008,7 @@
       "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
       "dev": true,
       "requires": {
-        "eslint": "^4.19.1"
+        "eslint": "4.19.1"
       }
     },
     "rimraf": {
@@ -3906,7 +4017,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -3915,56 +4026,13 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
-        }
-      }
-    },
-    "router": {
-      "version": "github:blakeembrey/router#5eb68560e91b302251ff17a70cd1b6af1fc36d30",
-      "from": "github:blakeembrey/router#router-engine",
-      "requires": {
-        "array-flatten": "2.0.0",
-        "debug": "^3.1.0",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.1",
-        "path-to-regexp": "0.1.7",
-        "setprototypeof": "1.0.0",
-        "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "array-flatten": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.0.0.tgz",
-          "integrity": "sha1-JN2Ys4uRlLWbIIe6QMIThNa4qNw="
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "setprototypeof": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.0.tgz",
-          "integrity": "sha1-1fr8oB4RdNAHm9G/iB8JyKM5eUw="
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
         }
       }
     },
@@ -3974,7 +4042,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-parallel": {
@@ -3995,7 +4063,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "rxjs": {
@@ -4025,7 +4093,8 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",
@@ -4034,18 +4103,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -4063,10 +4132,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.4.0"
           }
         },
         "statuses": {
@@ -4082,8 +4151,8 @@
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
+        "no-case": "2.3.2",
+        "upper-case-first": "1.1.2"
       }
     },
     "serve-static": {
@@ -4092,9 +4161,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -4124,19 +4193,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -4144,7 +4216,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snake-case": {
@@ -4152,7 +4224,7 @@
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "spawn-sync": {
@@ -4161,8 +4233,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
       }
     },
     "spawn-wrap": {
@@ -4171,12 +4243,12 @@
       "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
       "dev": true,
       "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
+        "foreground-child": "1.5.6",
+        "mkdirp": "0.5.1",
+        "os-homedir": "1.0.2",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "which": "1.3.1"
       }
     },
     "spdx-correct": {
@@ -4185,8 +4257,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-exceptions": {
@@ -4201,8 +4273,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-license-ids": {
@@ -4223,15 +4295,15 @@
       "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
       "dev": true,
       "requires": {
-        "eslint": "~5.4.0",
+        "eslint": "5.4.0",
         "eslint-config-standard": "12.0.0",
         "eslint-config-standard-jsx": "6.0.2",
-        "eslint-plugin-import": "~2.14.0",
-        "eslint-plugin-node": "~7.0.1",
-        "eslint-plugin-promise": "~4.0.0",
-        "eslint-plugin-react": "~7.11.1",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~9.0.0"
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-react": "7.11.1",
+        "eslint-plugin-standard": "4.0.0",
+        "standard-engine": "9.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -4258,7 +4330,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "eslint": {
@@ -4267,44 +4339,44 @@
           "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
           "dev": true,
           "requires": {
-            "ajv": "^6.5.0",
-            "babel-code-frame": "^6.26.0",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.5",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^4.0.0",
-            "eslint-utils": "^1.3.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^4.0.0",
-            "esquery": "^1.0.1",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.7.0",
-            "ignore": "^4.0.2",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^5.2.0",
-            "is-resolvable": "^1.1.0",
-            "js-yaml": "^3.11.0",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.5",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^2.0.0",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.5.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "^2.0.1",
-            "table": "^4.0.3",
-            "text-table": "^0.2.0"
+            "ajv": "6.6.1",
+            "babel-code-frame": "6.26.0",
+            "chalk": "2.4.1",
+            "cross-spawn": "6.0.5",
+            "debug": "3.2.6",
+            "doctrine": "2.1.0",
+            "eslint-scope": "4.0.0",
+            "eslint-utils": "1.3.1",
+            "eslint-visitor-keys": "1.0.0",
+            "espree": "4.1.0",
+            "esquery": "1.0.1",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "functional-red-black-tree": "1.0.1",
+            "glob": "7.1.3",
+            "globals": "11.9.0",
+            "ignore": "4.0.6",
+            "imurmurhash": "0.1.4",
+            "inquirer": "5.2.0",
+            "is-resolvable": "1.1.0",
+            "js-yaml": "3.12.0",
+            "json-stable-stringify-without-jsonify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "7.0.0",
+            "progress": "2.0.3",
+            "regexpp": "2.0.1",
+            "require-uncached": "1.0.3",
+            "semver": "5.6.0",
+            "strip-ansi": "4.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "4.0.3",
+            "text-table": "0.2.0"
           }
         },
         "eslint-scope": {
@@ -4313,8 +4385,8 @@
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         },
         "espree": {
@@ -4323,9 +4395,9 @@
           "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
           "dev": true,
           "requires": {
-            "acorn": "^6.0.2",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
+            "acorn": "6.0.4",
+            "acorn-jsx": "5.0.1",
+            "eslint-visitor-keys": "1.0.0"
           }
         },
         "estraverse": {
@@ -4340,12 +4412,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "ignore": {
@@ -4360,19 +4432,19 @@
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.1.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^5.5.2",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.3.0",
+            "rxjs": "5.5.12",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
           }
         },
         "ms": {
@@ -4393,12 +4465,12 @@
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {
-            "ajv": "^6.0.1",
-            "ajv-keywords": "^3.0.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
+            "ajv": "6.6.1",
+            "ajv-keywords": "3.2.0",
+            "chalk": "2.4.1",
+            "lodash": "4.17.11",
             "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         }
       }
@@ -4409,10 +4481,10 @@
       "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
       "dev": true,
       "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^6.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "deglob": "2.1.1",
+        "get-stdin": "6.0.0",
+        "minimist": "1.2.0",
+        "pkg-conf": "2.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -4438,7 +4510,7 @@
       "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-1.1.1.tgz",
       "integrity": "sha512-SaZxkvxujYBR6NTumhRTg/yztw2p30fzZ/jvSgQtlZFEGI7tdSNDaPbvT47QF92hx6Tar8hAhpr7ErpTNvtuCQ==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.12"
       }
     },
     "streamsearch": {
@@ -4450,17 +4522,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -4472,7 +4546,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -4485,8 +4560,8 @@
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
       }
     },
     "symbol-observable": {
@@ -4501,12 +4576,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.1",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -4515,10 +4590,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "fast-deep-equal": {
@@ -4541,10 +4616,10 @@
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
+        "glob": "7.1.3",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "4.0.0",
+        "require-main-filename": "2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -4553,12 +4628,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "load-json-file": {
@@ -4567,10 +4642,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.15",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "parse-json": {
@@ -4579,8 +4654,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -4589,7 +4664,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -4604,9 +4679,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -4615,8 +4690,8 @@
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "3.0.0",
+            "read-pkg": "3.0.0"
           }
         }
       }
@@ -4638,8 +4713,8 @@
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -4648,7 +4723,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-fast-properties": {
@@ -4668,8 +4743,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "1.1.31",
+        "punycode": "2.1.1"
       }
     },
     "trim-right": {
@@ -4697,7 +4772,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -4712,7 +4787,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.21"
       }
     },
     "typedarray": {
@@ -4728,8 +4803,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -4784,7 +4859,7 @@
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "requires": {
-        "upper-case": "^1.1.1"
+        "upper-case": "1.1.3"
       }
     },
     "uri-js": {
@@ -4792,7 +4867,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urlsafe-base64": {
@@ -4823,8 +4898,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validator": {
@@ -4841,8 +4916,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -4856,7 +4932,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "2.1.1"
       }
     },
     "wordwrap": {
@@ -4869,40 +4945,45 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -4910,7 +4991,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "0.2.1",
@@ -4918,7 +5000,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -4927,9 +5009,9 @@
       "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.15",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "xhr2": {
@@ -4942,8 +5024,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -4989,21 +5071,20 @@
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
     "yargs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "requires": {
-        "cliui": "^4.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.0.0"
+        "cliui": "5.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "2.0.5",
+        "require-directory": "2.1.1",
+        "require-main-filename": "2.0.0",
+        "set-blocking": "2.0.0",
+        "string-width": "3.1.0",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5011,14 +5092,32 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.3"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0",
+            "wrap-ansi": "5.1.0"
+          }
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -5026,7 +5125,26 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "requires": {
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -5035,9 +5153,10 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+      "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.3.1",
+        "decamelize": "1.2.0"
       }
     },
     "yargs-unparser": {
@@ -5046,9 +5165,9 @@
       "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.11",
-        "yargs": "^12.0.5"
+        "flat": "4.1.0",
+        "lodash": "4.17.11",
+        "yargs": "12.0.5"
       },
       "dependencies": {
         "get-caller-file": {
@@ -5069,18 +5188,18 @@
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "11.1.1"
           }
         },
         "yargs-parser": {
@@ -5089,8 +5208,8 @@
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -5101,10 +5220,10 @@
       "integrity": "sha512-+MXJmBRZvqn+LInpJBSSETK1XLQqyhKCCNqc7MY7FqiqWCTQddAahg5i0jlfX5dli7gvIfpJvijV3ZlAJRtZ1Q==",
       "optional": true,
       "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
+        "commander": "2.20.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "10.11.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "request-error-handler": "^1.1.1",
     "type-is": "^1.5.5",
     "xtend": "^4.0.0",
-    "yargs": "^13.2.2"
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "busboy": "^0.3.1",


### PR DESCRIPTION
…abilities

https://github.com/yargs/yargs/pull/1356
`yargs` < 13.3.0 include `os-local`, which has `execa` as a dependency
all versions of `execa` are vulnerable to command injection attacks. 